### PR TITLE
Setting document title based on page loaded through Ajax

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -73,9 +73,11 @@ jQuery(function($) {
         $.get(State.url, function(result) {
             var $html = $(result);
             var $newContent = $('#ajax-container', $html).contents();
+            var title = result.match(/<title>(.*?)<\/title>/)[1];
 
             $('html, body').animate({'scrollTop': 0});
             $ajaxContainer.fadeOut(500, function() {
+                document.title = title;
                 $ajaxContainer.html($newContent);
                 $ajaxContainer.fadeIn(500);
 				


### PR DESCRIPTION
Not the cleanest way, but somehow I couldn't use `$html.find('title')` or `$('title', $html)`, these couldn't find the title dom element.

And sorry for the mucking around with the issue thing, I was hoping I could attach this pull request to an issue easily afterwards.
Github noob :)
